### PR TITLE
Improve PDF fonts and auto classification details

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,18 +36,28 @@ UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 PRED_DIR.mkdir(parents=True, exist_ok=True)
 CATEGORIZED_DIR.mkdir(parents=True, exist_ok=True)
 
-# 注册中文字体，优先使用系统中的 Noto Sans CJK
+# 注册中文字体，依次尝试系统中的常见字体
 try:
-    font_path = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
-    if os.path.exists(font_path):
+    candidate_paths = [
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+        "C:/Windows/Fonts/simhei.ttf",
+    ]
+    font_path = None
+    for p in candidate_paths:
+        if os.path.exists(p):
+            font_path = p
+            break
+    if font_path:
         pdfmetrics.registerFont(TTFont("SimHei", font_path))
         font_manager.fontManager.addfont(font_path)
-    else:
-        win_font = "C:/Windows/Fonts/simhei.ttf"
-        pdfmetrics.registerFont(TTFont("SimHei", win_font))
-        font_manager.fontManager.addfont(win_font)
-    plt.rcParams["font.sans-serif"] = ["SimHei", "Noto Sans CJK SC", "DejaVu Sans"]
-    plt.rcParams["axes.unicode_minus"] = False
+        plt.rcParams["font.sans-serif"] = [
+            "SimHei",
+            "Noto Sans CJK SC",
+            "WenQuanYi Zen Hei",
+            "DejaVu Sans",
+        ]
+        plt.rcParams["axes.unicode_minus"] = False
 except Exception:
     pass
 

--- a/webapp/templates/classify_result.html
+++ b/webapp/templates/classify_result.html
@@ -214,7 +214,7 @@
                           {% for img in imgs[:6] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
-                              <img src="{{ url_for('static', filename='pred_vis/' ~ img) }}" class="img-fluid" alt="{{ img }}">
+                              <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/无缺陷/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}
@@ -251,7 +251,7 @@
                           {% for img in imgs[:6] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
-                              <img src="{{ url_for('static', filename='pred_vis/' ~ img) }}" class="img-fluid" alt="{{ img }}">
+                              <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/' ~ cls_name ~ '/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}

--- a/webapp/templates/classify_result.html
+++ b/webapp/templates/classify_result.html
@@ -80,9 +80,7 @@
                   <div class="text-center">
                     <canvas id="taskChart" style="max-width: 400px; margin: 0 auto;"></canvas>
                     {% if task_pie_base64 %}
-                    <noscript>
-                      <img src="data:image/png;base64,{{ task_pie_base64 }}" class="img-fluid mt-3" alt="任务分布图">
-                    </noscript>
+                    <img src="data:image/png;base64,{{ task_pie_base64 }}" class="img-fluid mt-3" alt="任务分布图">
                     {% endif %}
                   </div>
               </div>
@@ -135,9 +133,7 @@
                   <div class="text-center">
                     <canvas id="defectChart-{{ task }}" style="max-width: 400px; margin: 0 auto;"></canvas>
                     {% if chart_data.pie_chart %}
-                    <noscript>
-                      <img src="data:image/png;base64,{{ chart_data.pie_chart }}" class="img-fluid mt-3" alt="缺陷分布图">
-                    </noscript>
+                    <img src="data:image/png;base64,{{ chart_data.pie_chart }}" class="img-fluid mt-3" alt="缺陷分布图">
                     {% endif %}
                   </div>
               </div>
@@ -215,16 +211,16 @@
                       <div class="row mt-3">
                         {% set imgs = class_img_map[task].get('no_defect', []) %}
                         {% if imgs|length > 0 %}
-                          {% for img in imgs[:12] %}
+                          {% for img in imgs[:6] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
                               <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/无缺陷/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}
-                          {% if imgs|length > 12 %}
+                          {% if imgs|length > 6 %}
                           <div class="col-12">
-                            <p class="text-muted small">还有 {{ imgs|length - 12 }} 张图片...</p>
+                            <p class="text-muted small">还有 {{ imgs|length - 6 }} 张图片...</p>
                           </div>
                           {% endif %}
                         {% else %}
@@ -252,16 +248,16 @@
                         {% set cls_key = 'class_' ~ loop.index %}
                         {% set imgs = class_img_map[task].get(cls_key, []) %}
                         {% if imgs|length > 0 %}
-                          {% for img in imgs[:12] %}
+                          {% for img in imgs[:6] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
                               <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/' ~ cls_name ~ '/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}
-                          {% if imgs|length > 12 %}
+                          {% if imgs|length > 6 %}
                           <div class="col-12">
-                            <p class="text-muted small">还有 {{ imgs|length - 12 }} 张图片...</p>
+                            <p class="text-muted small">还有 {{ imgs|length - 6 }} 张图片...</p>
                           </div>
                           {% endif %}
                         {% else %}

--- a/webapp/templates/classify_result.html
+++ b/webapp/templates/classify_result.html
@@ -80,7 +80,9 @@
                   <div class="text-center">
                     <canvas id="taskChart" style="max-width: 400px; margin: 0 auto;"></canvas>
                     {% if task_pie_base64 %}
-                    <img src="data:image/png;base64,{{ task_pie_base64 }}" class="img-fluid mt-3" alt="任务分布图">
+                    <noscript>
+                      <img src="data:image/png;base64,{{ task_pie_base64 }}" class="img-fluid mt-3" alt="任务分布图">
+                    </noscript>
                     {% endif %}
                   </div>
               </div>
@@ -133,7 +135,9 @@
                   <div class="text-center">
                     <canvas id="defectChart-{{ task }}" style="max-width: 400px; margin: 0 auto;"></canvas>
                     {% if chart_data.pie_chart %}
-                    <img src="data:image/png;base64,{{ chart_data.pie_chart }}" class="img-fluid mt-3" alt="缺陷分布图">
+                    <noscript>
+                      <img src="data:image/png;base64,{{ chart_data.pie_chart }}" class="img-fluid mt-3" alt="缺陷分布图">
+                    </noscript>
                     {% endif %}
                   </div>
               </div>
@@ -211,16 +215,16 @@
                       <div class="row mt-3">
                         {% set imgs = class_img_map[task].get('no_defect', []) %}
                         {% if imgs|length > 0 %}
-                          {% for img in imgs[:6] %}
+                          {% for img in imgs[:12] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
                               <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/无缺陷/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}
-                          {% if imgs|length > 6 %}
+                          {% if imgs|length > 12 %}
                           <div class="col-12">
-                            <p class="text-muted small">还有 {{ imgs|length - 6 }} 张图片...</p>
+                            <p class="text-muted small">还有 {{ imgs|length - 12 }} 张图片...</p>
                           </div>
                           {% endif %}
                         {% else %}
@@ -248,16 +252,16 @@
                         {% set cls_key = 'class_' ~ loop.index %}
                         {% set imgs = class_img_map[task].get(cls_key, []) %}
                         {% if imgs|length > 0 %}
-                          {% for img in imgs[:6] %}
+                          {% for img in imgs[:12] %}
                           <div class="col-md-2 col-sm-4 mb-2">
                             <div class="image-item-small">
                               <img src="{{ url_for('static', filename='categorized/auto_classify/' ~ task_info.tasks[task].task_name_cn ~ '/' ~ cls_name ~ '/' ~ img) }}" class="img-fluid" alt="{{ img }}">
                             </div>
                           </div>
                           {% endfor %}
-                          {% if imgs|length > 6 %}
+                          {% if imgs|length > 12 %}
                           <div class="col-12">
-                            <p class="text-muted small">还有 {{ imgs|length - 6 }} 张图片...</p>
+                            <p class="text-muted small">还有 {{ imgs|length - 12 }} 张图片...</p>
                           </div>
                           {% endif %}
                         {% else %}

--- a/webapp/templates/report.html
+++ b/webapp/templates/report.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
       font-family: 'SimHei';
-      src: url('file:///usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc') format('truetype');
+      src: url('file:///usr/share/fonts/truetype/wqy/wqy-zenhei.ttc') format('truetype');
     }
     body {
       font-family: 'SimHei', 'Noto Sans CJK SC', 'Microsoft YaHei', Arial, sans-serif;
@@ -307,13 +307,6 @@
     </div>
 
     {% for t, counts in class_counts_all.items() %}
-    {% set has_defects = false %}
-    {% for cname, cnt in counts.items() %}
-      {% if cnt > 0 %}
-        {% set has_defects = true %}
-      {% endif %}
-    {% endfor %}
-    {% if has_defects %}
     <div class="section">
       <h3>{{ task_info.tasks[t].task_name_cn }}缺陷类型统计</h3>
       <table>
@@ -342,7 +335,6 @@
       </div>
       {% endif %}
     </div>
-    {% endif %}
     {% endfor %}
 
     {% else %}


### PR DESCRIPTION
## Summary
- fix Chinese font registration and fallback
- include WQY font path in report template
- show categorized images in auto classify results
- always display per-task defect stats in PDF report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687298f819cc832285295af1cd17a0b1