### PR TITLE
Add model parameter count script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ python -m engine.infer_cls \
 
 以上命令将在指定目录下保存可视化结果，并在终端打印评估指标。
 
+### 模型参数量计算
+
+仓库新增 `count_params.py` 脚本，可统计任意 `.pth` 权重文件的参数总数：
+
+```bash
+python count_params.py logs/steel_model/best_model_v11.pth
+```
+
+脚本会输出参数量及按 `float32` 估算的模型大小。
+
 ## Web 演示
 
 `webapp/` 目录提供了一个基于 Flask 的简单前端，可对上传的图片进行分类和分割演示：

--- a/count_params.py
+++ b/count_params.py
@@ -1,0 +1,38 @@
+import argparse
+import torch
+from typing import Any, Dict
+
+
+def load_state_dict(path: str) -> Dict[str, torch.Tensor]:
+    """Load a PyTorch state dict from a .pth file."""
+    obj: Any = torch.load(path, map_location="cpu")
+    if isinstance(obj, dict):
+        # If the values are tensors, we assume this is already a state dict
+        if all(isinstance(v, torch.Tensor) for v in obj.values()):
+            return obj
+        # Common wrappers
+        for key in ["state_dict", "model", "model_state_dict", "weights"]:
+            if key in obj and isinstance(obj[key], dict):
+                return obj[key]
+    raise ValueError(f"Unable to find state dict in file: {path}")
+
+
+def count_parameters(state_dict: Dict[str, torch.Tensor]) -> int:
+    """Return total number of parameters in the state dict."""
+    return int(sum(v.numel() for v in state_dict.values()))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Count parameters in a .pth model file")
+    ap.add_argument("model_path", help="Path to the model weights (.pth)")
+    args = ap.parse_args()
+
+    state_dict = load_state_dict(args.model_path)
+    total = count_parameters(state_dict)
+    size_mb = total * 4 / 1e6  # assuming float32 weights
+    print(f"Total parameters: {total:,}")
+    print(f"Approx. storage size: {size_mb:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `count_params.py` to calculate parameter count for any `.pth` file
- document script usage in README
- fix typing for older Python versions

## Testing
- `python -m py_compile count_params.py`
- `python count_params.py dummy.pth`

------
https://chatgpt.com/codex/tasks/task_e_6878adeebca083228df32004babaacf4